### PR TITLE
Cleanup helper functions

### DIFF
--- a/helpers/gameHelper.mjs
+++ b/helpers/gameHelper.mjs
@@ -1,48 +1,39 @@
 import { mapPlayer } from "./playerHelper.mjs";
 
 export function mapLeagues(ls) {
-  // TODO: clean this up?
-  const count = ls.count;
-  const leagues = [];
+  const leagues = Object.values(ls);
 
-  for (let i = 0; i < count; i++) {
-    leagues.push(ls[i].league[0]);
-  }
-
-  return leagues;
-}
-
-// todo: again, this should be more re-usable
-export function mapPlayers(ps) {
-  // TODO: clean this up?
-  const count = ps.count;
-  let players = [];
-
-  for (let i = 0; i < count; i++) {
-    let player = ps[i].player[0];
-
-    // TODO: i hate this, it can def be better...
-    for (let j = ps[i].player.length - 1; j > 0; j--) {
-      player.push(ps[i].player[j]);
+  return leagues.reduce((result, l) => {
+    if (l.league) {
+      result.push(l.league[0]);
     }
 
-    players.push(player);
-  }
-  players = players.map(p => mapPlayer(p));
+    return result;
+  }, []);
+}
 
-  return players;
+export function mapPlayers(ps) {
+  const players = Object.values(ps);
+
+  return players.reduce((result, p) => {
+    if (p.player) {
+      result.push(mapPlayer(p.player[0]));
+    }
+
+    return result;
+  }, []);
 }
 
 export function mapWeeks(ws) {
-  // TODO: clean this up?
-  const count = ws.count;
-  const weeks = [];
+  const weeks = Object.values(ws);
 
-  for (let i = 0; i < count; i++) {
-    weeks.push(ws[i].game_week);
-  }
+  return weeks.reduce((result, w) => {
+    if (w.game_week) {
+      result.push(w.game_week);
+    }
 
-  return weeks;
+    return result;
+  }, []);
 }
 
 export function mapStatCategories(statcats) {

--- a/helpers/leagueHelper.mjs
+++ b/helpers/leagueHelper.mjs
@@ -9,7 +9,7 @@ export function mapTeams(ts) {
 
   return teams.reduce((result, t) => {
     if (t.team) {
-      result.push(t.team[0]);
+      result.push(mapTeam(t.team[0]));
     }
 
     return result;

--- a/helpers/leagueHelper.mjs
+++ b/helpers/leagueHelper.mjs
@@ -5,14 +5,15 @@ import { mapTransactionPlayers } from "./transactionHelper.mjs";
  * Helper function to map data to a "team"
  */
 export function mapTeams(ts) {
-  const count = ts.count;
-  const teams = [];
+  const teams = Object.values(ts);
 
-  for (let i = 0; i < count; i++) {
-    teams.push(mapTeam(ts[i].team[0]));
-  }
+  return teams.reduce((result, t) => {
+    if (t.team) {
+      result.push(t.team[0]);
+    }
 
-  return teams;
+    return result;
+  }, []);
 }
 
 export function mapStandings(ts) {
@@ -45,50 +46,49 @@ export function mapSettings(settings) {
 }
 
 export function mapDraft(d) {
-  const count = d.count;
-  const draft = [];
+  const draft = Object.values(d);
 
-  for (let i = 0; i < count; i++) {
-    draft.push(d[i].draft_result);
-  }
+  return draft.reduce((result, d) => {
+    if (d.draft_result) {
+      result.push(d.draft_result);
+    }
 
-  return draft;
+    return result;
+  }, []);
 }
 
-export function mapScoreboard(scoreboard) {
-  const count = scoreboard.count;
-  let matchups = [];
+export function mapScoreboard(sb) {
+  const scoreboard = Object.values(sb);
 
-  for (let i = 0; i < count; i++) {
-    matchups.push(scoreboard[i].matchup);
-  }
+  // TODO this is still gross... 3 array iterations :(
+  const matchups = scoreboard.reduce((result, m) => {
+    if (m.matchup) {
+      m = m.matchup;
+      if (m.matchup_grades) {
+        m.matchup_grades = m.matchup_grades.map(grade => {
+          return {
+            team_key: grade.matchup_grade.team_key,
+            grade: grade.matchup_grade.grade
+          };
+        });
+      }
 
-  matchups = matchups.map(m => {
-    if (m.matchup_grades) {
-      m.matchup_grades = m.matchup_grades.map(grade => {
-        return {
-          team_key: grade.matchup_grade.team_key,
-          grade: grade.matchup_grade.grade
-        };
-      });
+      const teams = Object.values(m[0].teams);
+      m.teams = teams.reduce((result, t) => {
+        if (t.team) {
+          let team = mapTeam(t.team[0]);
+          team = mapTeamPoints(team, t.team[1]);
+          result.push(team);
+        }
+
+        return result;
+      }, []);
+
+      result.push(m);
     }
 
-    // TODO: i feel like i should be able to use map teams here...
-    const count = m[0].teams.count;
-    let teams = [];
-
-    for (let i = 0; i < count; i++) {
-      let team = mapTeam(m[0].teams[i].team[0]);
-      team = mapTeamPoints(team, m[0].teams[i].team[1]);
-
-      teams.push(team);
-    }
-
-    delete m[0];
-    m.teams = teams;
-
-    return m;
-  });
+    return result;
+  }, []);
 
   return {
     matchups: matchups,

--- a/helpers/leagueHelper.mjs
+++ b/helpers/leagueHelper.mjs
@@ -61,7 +61,7 @@ export function mapScoreboard(sb) {
   const scoreboard = Object.values(sb);
 
   // TODO this is still gross... 3 array iterations :(
-  const matchups = scoreboard.reduce((result, m) => {
+  const matchups = scoreboard.reduce((matchupsResult, m) => {
     if (m.matchup) {
       m = m.matchup;
       if (m.matchup_grades) {
@@ -74,20 +74,24 @@ export function mapScoreboard(sb) {
       }
 
       const teams = Object.values(m[0].teams);
-      m.teams = teams.reduce((result, t) => {
+
+      // Remove raw data entry from the matchup
+      delete m[0];
+
+      m.teams = teams.reduce((teamsResult, t) => {
         if (t.team) {
           let team = mapTeam(t.team[0]);
           team = mapTeamPoints(team, t.team[1]);
-          result.push(team);
+          teamsResult.push(team);
         }
 
-        return result;
+        return teamsResult;
       }, []);
 
-      result.push(m);
+      matchupsResult.push(m);
     }
 
-    return result;
+    return matchupsResult;
   }, []);
 
   return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yahoo-fantasy",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/leagueResource.spec.js
+++ b/tests/leagueResource.spec.js
@@ -91,11 +91,17 @@ describe("resource: leagueResource", function() {
 
   // scoreboard
   it("should build a proper url to retrieve scoreboard via a league key", function(done) {
+    var mockLeagueScoreboard = require("./nock-data/leagueScoreboard");
     nock("https://fantasysports.yahooapis.com")
       .get("/fantasy/v2/league/328.l.34014/scoreboard?format=json")
-      .reply(200, require("./nock-data/leagueScoreboard"));
+      .reply(200, mockLeagueScoreboard);
 
-    league.scoreboard("328.l.34014", done);
+    league.scoreboard("328.l.34014", function(e, data) {
+      expect(data.league_key).toEqual(mockLeagueScoreboard.fantasy_content.league[0].league_key);
+      expect(data.scoreboard.matchups[0].teams[0].name).toEqual(mockLeagueScoreboard.fantasy_content.league[1].scoreboard[0].matchups[0].matchup[0].teams[0].team[0][2].name);
+
+      done();
+    });
 
     expect(yf.api).toHaveBeenCalledWith(
       "GET",


### PR DESCRIPTION
I noticed that you had some comments in the code for cleanup on helper functions.

I started going through them and with the combination of `Object.values` and `Array.reduce` I was able to achieve the object formatting you wanted and also remove the dependency on pulling a `count` value from the API Response. I know that JavaScript object property order is predictable but it still seemed gross and cleaned up the code a bit.

.. inside `mapScoreboard` I was also able to reduce the array iterations from 4 to 3... still some work we can likely do there though.

All tests run and pass
`Executed 98 of 98 specs SUCCESS in 0.214 sec.`