### PR TITLE
TypeError: date.indexOf is not a function in rosterResource.mjs

### DIFF
--- a/resources/rosterResource.mjs
+++ b/resources/rosterResource.mjs
@@ -13,7 +13,7 @@ class RosterResource {
 
     if (args.length) {
       let date = args.pop();
-      if (date.indexOf("-") > 0) {
+      if (!Number.isInteger(date) && date.indexOf("-") > 0) {
         // string is date, of format y-m-d
         url += `;date=${date}`;
       } else {


### PR DESCRIPTION
I ran into an error while fetching data between an MLB league and an NFL league.  If it was NFL, the 'date' value was coming as a integer.  But it was throwing an error because you cannot do an indexOf() on an integer.   

I changed the logic to check if the number is not an integer before doing the indexOf (which might not even be necessary anymore).