### PR TITLE
Correctly refresh the token and re-call the API

### DIFF
--- a/YahooFantasy.mjs
+++ b/YahooFantasy.mjs
@@ -288,12 +288,12 @@ class YahooFantasy {
 
             if (data.error) {
               if (/"token_expired"/i.test(data.error.description)) {
-                this.refreshToken((err, data) => {
+                return this.refreshToken((err, data) => {
                   if (err) {
                     return reject(err);
                   }
 
-                  return this.api(method, url, postData);
+                  return resolve(this.api(method, url, postData));
                 });
               } else {
                 return reject(data.error);


### PR DESCRIPTION
Previously, the API call was retried if a token needed to be refreshed, but the response wasn't included in the promise chain, and instead the error was returned. This change moves the retried call into the chain.