### PR TITLE
fix error loading certain league settings

### DIFF
--- a/helpers/leagueHelper.mjs
+++ b/helpers/leagueHelper.mjs
@@ -31,9 +31,9 @@ export function mapStandings(ts) {
 
 export function mapSettings(settings) {
   settings.stat_categories = settings.stat_categories.stats.map((s) => {
-    s.stat.stat_position_types = s.stat.stat_position_types.map(
-      (pt) => pt.stat_position_type.position_type
-    );
+    s.stat.stat_position_types = s.stat.stat_position_types
+      ? s.stat.stat_position_types.map((pt) => pt.stat_position_type.position_type)
+      : [];
 
     return s.stat;
   });


### PR DESCRIPTION
It seems like some (older?) leagues are missing this, which causes an error when retrieving their settings.