### PR TITLE
Fix: Issue 77 - Return Stats When Specifying Week/Date

### DIFF
--- a/resources/playerResource.mjs
+++ b/resources/playerResource.mjs
@@ -39,7 +39,14 @@ class PlayerResource {
     const cb = extractCallback(args);
 
     if (args.length) {
-      url += `;week=${args.pop()}`;
+      let date = args.pop();
+      if (date.indexOf("-") > 0) {
+        // string is date, of format y-m-d
+        url += `;type=date;date=${date}`;
+      } else {
+        // number is week...
+        url += `;type=week;week=${date}`;
+      }
     }
 
     console.log(url);


### PR DESCRIPTION
Previously, only season stats would be returning for a player regardless if someone enters a week or date as a second argument.

The request string needs to specify what type of argument it is sending, and the stats method was not specifying that type. I updated `playerResource.mjs` to include an if/else statement that actually exists on the `teamResource.mjs` file and works the exact same.