### PR TITLE
Get player stats for lastweek or lastmonth

### DIFF
--- a/resources/playerResource.mjs
+++ b/resources/playerResource.mjs
@@ -42,7 +42,10 @@ class PlayerResource {
     if (args.length) {
       const date = args.pop();
       // TODO: I could get more clever here, but need it working first...
-      if (date.indexOf("-") > 0) {
+      if (date === "lastweek" || date === "lastmonth") {
+        dateType = date;
+        url += `;type=${date}`;
+      } else if (date.indexOf("-") > 0) {
         dateType = "date";
         // string is date, of format y-m-d
         url += `;type=date;date=${date}`;


### PR DESCRIPTION
Adds two additional options for the date argument when calling `yf.player.stats(
  player_key,
  date // optional
)`

The new options are 'lastweek' and 'lastmonth'. When these options are called the API will return the player's stats for the last week and last month, respectively.

e.g. `yf.player.stats( 'nhl.p.7626', 'lastmonth')` will return Jeremy Swayman's stats for the last month.