### PR TITLE
feature: add support for scope in request parameter to api.login.yahoo.com/oauth2/request_auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ node_modules
 .esm-cache
 .vs-code
 dump.rdb
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "vsicons.presets.angular": false
-}

--- a/YahooFantasy.mjs
+++ b/YahooFantasy.mjs
@@ -31,7 +31,7 @@ class YahooFantasy {
     this.CONSUMER_SECRET = consumerSecret;
     this.REDIRECT_URI = redirectUri;
 
-    this.refreshTokenCallback = () => {};
+    this.refreshTokenCallback = () => { };
 
     if (tokenCallbackFn) {
       this.refreshTokenCallback = tokenCallbackFn;
@@ -65,7 +65,7 @@ class YahooFantasy {
   }
 
   // oauth2 authenticatiocn function -- follow redirect to yahoo login
-  auth(res, state = null) {
+  auth(res, state = null, scope = null) {
     const authData = {
       client_id: this.CONSUMER_KEY,
       redirect_uri: this.REDIRECT_URI,
@@ -74,6 +74,10 @@ class YahooFantasy {
 
     if (state) {
       authData.state = state;
+    }
+
+    if (scope) {
+      authData.scope = scope
     }
 
     const options = {
@@ -140,12 +144,12 @@ class YahooFantasy {
       });
 
       tokenReponse.on("end", async () => {
-        const { access_token, refresh_token } = JSON.parse(
+        const data = JSON.parse(
           Buffer.concat(chunks)
         );
 
-        this.yahooUserToken = access_token;
-        this.yahooRefreshToken = refresh_token;
+        this.yahooUserToken = data.access_token;
+        this.yahooRefreshToken = data.refresh_token;
 
         if (this.refreshTokenCallback) {
           // run the callback before moving on
@@ -155,7 +159,7 @@ class YahooFantasy {
           });
         }
 
-        cb(null, { access_token, refresh_token, state });
+        cb(null, { ...data, state });
       });
     });
 

--- a/YahooFantasy.mjs
+++ b/YahooFantasy.mjs
@@ -147,9 +147,10 @@ class YahooFantasy {
         const data = JSON.parse(
           Buffer.concat(chunks)
         );
+        const { access_token, refresh_token } = data;
 
-        this.yahooUserToken = data.access_token;
-        this.yahooRefreshToken = data.refresh_token;
+        this.yahooUserToken = access_token;
+        this.yahooRefreshToken = refresh_token;
 
         if (this.refreshTokenCallback) {
           // run the callback before moving on

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /* global module, require */
 require = require("esm")(module, true);
 module.exports = require("./YahooFantasy.mjs").default;
-
+module.exports.teamHelper = require('./helpers/teamHelper.mjs');
 // TODO: league settings sample data
 // TODO: transactions sample data

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yahoo-fantasy",
-  "version": "5.2.2",
+  "version": "5.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "yahoo-fantasy",
-      "version": "5.2.2",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
         "esm": "^3.2.25",


### PR DESCRIPTION
[As per the docs here](https://developer.yahoo.com/oauth2/guide/openid_connect/getting_started.html#step-1-send-an-authentication-request-to-yahoo), I added the option in the `auth()` method to take in a third argument for scope, it works the same way as state, where it's only set if it's present.

This option allows the auth method to return a `id_token` which contains a JWT that is digitally signed by Yahoo, in which contains identity information about the user. This information can help create accounts and have data about the user being authetnicated, like their email, first name, etc. This information will be mention on the Yahoo Login when they are redirected to the login page.

In addition, I updated the callback method to include the entire response body instead of just the auth token and refresh, since we don't want to limit the response here and just return all the possible properties there are. 

If you need anything else in this PR please let me know ! :)


