### PR TITLE
feat: write API foundation + roster lineup editing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,11 @@ npm run test:all      # Run all test suites
 3. Set `RUN_INTEGRATION_TESTS=true`
 4. Run `npm run test:integration`
 
+### Write Operations
+Write operations (roster.update, transactions.*, transaction.*) are covered by
+unit tests only (mocked HTTP, asserting method/URL/XML body). They are
+intentionally excluded from integration tests because they mutate real leagues.
+
 ## Common Issues & Solutions
 
 ### 1. OAuth Signature Import

--- a/src/YahooFantasy.ts
+++ b/src/YahooFantasy.ts
@@ -44,6 +44,8 @@ class YahooFantasy {
 
   public readonly GET: HttpMethod = "GET";
   public readonly POST: HttpMethod = "POST";
+  public readonly PUT: HttpMethod = "PUT";
+  public readonly DELETE: HttpMethod = "DELETE";
 
   public game: Game;
   public games: Games;
@@ -371,8 +373,11 @@ class YahooFantasy {
             oauth_signature: decodeURIComponent(signature),
           };
         } else {
-          // OAuth 2.0 flow
           headers.Authorization = `Bearer ${this.yahooUserToken}`;
+        }
+
+        if (postData && (method === "POST" || method === "PUT")) {
+          headers["Content-Type"] = "application/xml";
         }
 
         const options: https.RequestOptions = {
@@ -428,7 +433,7 @@ class YahooFantasy {
           reject(new Error(err.message));
         });
 
-        if (postData && method === "POST") {
+        if (postData && (method === "POST" || method === "PUT")) {
           request.write(
             typeof postData === "string" ? postData : JSON.stringify(postData)
           );

--- a/src/helpers/xmlHelper.ts
+++ b/src/helpers/xmlHelper.ts
@@ -6,3 +6,34 @@ export function escapeXml(value: string | number): string {
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;");
 }
+
+const DECL = "<?xml version='1.0'?>";
+
+export type RosterCoverage = { week: number } | { date: string };
+export interface RosterSlot {
+  player_key: string;
+  position: string;
+}
+
+export function buildRosterPayload(
+  coverage: RosterCoverage,
+  players: RosterSlot[]
+): string {
+  const cov =
+    "week" in coverage
+      ? `<coverage_type>week</coverage_type><week>${escapeXml(
+          coverage.week
+        )}</week>`
+      : `<coverage_type>date</coverage_type><date>${escapeXml(
+          coverage.date
+        )}</date>`;
+  const playerEls = players
+    .map(
+      (p) =>
+        `<player><player_key>${escapeXml(
+          p.player_key
+        )}</player_key><position>${escapeXml(p.position)}</position></player>`
+    )
+    .join("");
+  return `${DECL}<fantasy_content><roster>${cov}<players>${playerEls}</players></roster></fantasy_content>`;
+}

--- a/src/helpers/xmlHelper.ts
+++ b/src/helpers/xmlHelper.ts
@@ -1,0 +1,8 @@
+export function escapeXml(value: string | number): string {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}

--- a/src/resources/rosterResource.ts
+++ b/src/resources/rosterResource.ts
@@ -2,6 +2,7 @@ import { YahooFantasyInstance, Callback } from "../types/core";
 import { MappedTeam, FantasyContent } from "../types/api-responses";
 import { mapTeam, mapRoster } from "../helpers/teamHelper";
 import { extractCallback } from "../helpers/argsParser";
+import { buildRosterPayload, RosterCoverage, RosterSlot } from "../helpers/xmlHelper";
 
 class RosterResource {
   constructor(private yf: YahooFantasyInstance) {}
@@ -154,6 +155,33 @@ class RosterResource {
       return;
     }
     return resultPromise;
+  }
+  update(
+    teamKey: string,
+    coverage: RosterCoverage,
+    players: RosterSlot[]
+  ): Promise<any>;
+  update(
+    teamKey: string,
+    coverage: RosterCoverage,
+    players: RosterSlot[],
+    cb: Callback<any>
+  ): void;
+  update(
+    teamKey: string,
+    coverage: RosterCoverage,
+    players: RosterSlot[],
+    cb?: Callback<any>
+  ): Promise<any> | void {
+    const url = `https://fantasysports.yahooapis.com/fantasy/v2/team/${teamKey}/roster`;
+    const body = buildRosterPayload(coverage, players);
+    const promise = this.yf.api(this.yf.PUT, url, body) as Promise<any>;
+
+    if (cb) {
+      promise.then((data) => cb(null, data)).catch((e) => cb(e));
+      return;
+    }
+    return promise;
   }
 }
 

--- a/src/resources/rosterResource.ts
+++ b/src/resources/rosterResource.ts
@@ -156,6 +156,7 @@ class RosterResource {
     }
     return resultPromise;
   }
+
   update(
     teamKey: string,
     coverage: RosterCoverage,

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -78,6 +78,8 @@ export interface YahooFantasyInstance {
   
   GET: HttpMethod;
   POST: HttpMethod;
+  PUT: HttpMethod;
+  DELETE: HttpMethod;
   
   // Method to make API requests
   api(

--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -5,6 +5,8 @@ import {
   BaseResource
 } from './core';
 
+import { RosterCoverage, RosterSlot } from '../helpers/xmlHelper';
+
 import {
   Game,
   GameWeek,
@@ -133,6 +135,9 @@ export interface RosterResource extends BaseResource {
   players(teamKey: string, date: string): Promise<MappedTeam>;
   players(teamKey: string, week: number, cb: Callback<MappedTeam>): void;
   players(teamKey: string, week: number): Promise<MappedTeam>;
+
+  update(teamKey: string, coverage: RosterCoverage, players: RosterSlot[]): Promise<any>;
+  update(teamKey: string, coverage: RosterCoverage, players: RosterSlot[], cb: Callback<any>): void;
 }
 
 // Transaction Resource

--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -53,8 +53,8 @@ export interface LeagueResource extends BaseResource {
   settings(leagueKey: string, cb: Callback<LeagueSettings>): void;
   settings(leagueKey: string): Promise<LeagueSettings>;
   
-  standings(leagueKey: string, cb: Callback<MappedTeam[]>): void;
-  standings(leagueKey: string): Promise<MappedTeam[]>;
+  standings(leagueKey: string, cb: Callback<League & { standings: MappedTeam[] }>): void;
+  standings(leagueKey: string): Promise<League & { standings: MappedTeam[] }>;
   
   scoreboard(leagueKey: string, week: number, cb: Callback<any>): void;
   scoreboard(leagueKey: string, week: number): Promise<any>;

--- a/test-typescript.ts
+++ b/test-typescript.ts
@@ -5,11 +5,11 @@
  */
 
 import * as dotenv from 'dotenv';
-import YahooFantasy, { 
-  Game, 
-  League, 
-  Player, 
-  Team, 
+import YahooFantasy, {
+  Game,
+  League,
+  MappedPlayer,
+  Team,
   GameResource,
   LeagueResource,
   PlayerResource
@@ -96,7 +96,7 @@ try {
   // Promise versions (return type inference)
   const gamePromise: Promise<Game> = yf.game.meta('328');
   const leaguePromise: Promise<League> = yf.league.meta('328.l.123');
-  const playerPromise: Promise<Player> = yf.player.meta('328.p.123');
+  const playerPromise: Promise<MappedPlayer> = yf.player.meta('328.p.123');
   
   console.log('✅ Callback overloads compile correctly');
   console.log('✅ Promise overloads compile correctly');

--- a/tests/apiWrite.spec.js
+++ b/tests/apiWrite.spec.js
@@ -1,0 +1,47 @@
+const YahooFantasy = require("../index.js");
+const nock = require("nock");
+
+describe("api(): write methods", function () {
+  const yf = new YahooFantasy("Y!KEY", "Y!SECRET");
+
+  beforeEach(function () {
+    yf.setUserToken("testusertoken==");
+  });
+
+  it("exposes PUT and DELETE method constants", function () {
+    expect(yf.PUT).toBe("PUT");
+    expect(yf.DELETE).toBe("DELETE");
+  });
+
+  it("sends an XML body with Content-Type for PUT", function () {
+    const body = "<?xml version='1.0'?><fantasy_content></fantasy_content>";
+    let sentCT;
+    nock("https://fantasysports.yahooapis.com", {
+      reqheaders: {
+        "content-type": (v) => {
+          sentCT = v;
+          return true;
+        },
+      },
+    })
+      .put("/fantasy/v2/team/x/roster?format=json", body)
+      .reply(200, { ok: true });
+
+    return yf
+      .api(yf.PUT, "https://fantasysports.yahooapis.com/fantasy/v2/team/x/roster", body)
+      .then((res) => {
+        expect(res.ok).toBe(true);
+        expect(sentCT).toBe("application/xml");
+      });
+  });
+
+  it("sends a DELETE with no body", function () {
+    nock("https://fantasysports.yahooapis.com")
+      .delete("/fantasy/v2/transaction/y?format=json")
+      .reply(200, { ok: true });
+
+    return yf
+      .api(yf.DELETE, "https://fantasysports.yahooapis.com/fantasy/v2/transaction/y")
+      .then((res) => expect(res.ok).toBe(true));
+  });
+});

--- a/tests/rosterResource.spec.js
+++ b/tests/rosterResource.spec.js
@@ -32,3 +32,38 @@ describe("resource: rosterResource", function() {
     return result;
   });
 });
+
+describe("resource: rosterResource.update", function () {
+  const yf = new YahooFantasy("Y!KEY", "Y!SECRET");
+  const roster = yf.roster;
+
+  beforeEach(function () {
+    yf.setUserToken("testusertoken==");
+    spyOn(yf, "api").and.callThrough();
+  });
+
+  it("PUTs the roster XML for week coverage", function () {
+    const expected =
+      "<?xml version='1.0'?><fantasy_content><roster>" +
+      "<coverage_type>week</coverage_type><week>3</week><players>" +
+      "<player><player_key>nfl.p.1</player_key><position>WR</position></player>" +
+      "</players></roster></fantasy_content>";
+
+    nock("https://fantasysports.yahooapis.com")
+      .put("/fantasy/v2/team/nfl.l.1.t.1/roster?format=json", expected)
+      .reply(200, { fantasy_content: {} });
+
+    const result = roster.update(
+      "nfl.l.1.t.1",
+      { week: 3 },
+      [{ player_key: "nfl.p.1", position: "WR" }]
+    );
+
+    expect(yf.api).toHaveBeenCalledWith(
+      "PUT",
+      "https://fantasysports.yahooapis.com/fantasy/v2/team/nfl.l.1.t.1/roster",
+      expected
+    );
+    return result;
+  });
+});

--- a/tests/rosterResource.spec.js
+++ b/tests/rosterResource.spec.js
@@ -66,4 +66,21 @@ describe("resource: rosterResource.update", function () {
     );
     return result;
   });
+
+  it("invokes the callback with data on success", function (done) {
+    nock("https://fantasysports.yahooapis.com")
+      .put("/fantasy/v2/team/nfl.l.1.t.2/roster?format=json")
+      .reply(200, { fantasy_content: {} });
+
+    roster.update(
+      "nfl.l.1.t.2",
+      { week: 3 },
+      [{ player_key: "nfl.p.2", position: "QB" }],
+      function (err, data) {
+        expect(err).toBeNull();
+        expect(data).toEqual({ fantasy_content: {} });
+        done();
+      }
+    );
+  });
 });

--- a/tests/xmlHelper.spec.js
+++ b/tests/xmlHelper.spec.js
@@ -1,0 +1,13 @@
+const { escapeXml } = require("../dist/cjs/helpers/xmlHelper");
+
+describe("xmlHelper.escapeXml", function () {
+  it("escapes XML metacharacters", function () {
+    expect(escapeXml(`a & b < c > d " e ' f`)).toBe(
+      "a &amp; b &lt; c &gt; d &quot; e &apos; f"
+    );
+  });
+
+  it("stringifies non-strings", function () {
+    expect(escapeXml(10)).toBe("10");
+  });
+});

--- a/tests/xmlHelper.spec.js
+++ b/tests/xmlHelper.spec.js
@@ -1,4 +1,4 @@
-const { escapeXml } = require("../dist/cjs/helpers/xmlHelper");
+const { escapeXml, buildRosterPayload } = require("../dist/cjs/helpers/xmlHelper");
 
 describe("xmlHelper.escapeXml", function () {
   it("escapes XML metacharacters", function () {
@@ -9,5 +9,33 @@ describe("xmlHelper.escapeXml", function () {
 
   it("stringifies non-strings", function () {
     expect(escapeXml(10)).toBe("10");
+  });
+});
+
+describe("xmlHelper.buildRosterPayload", function () {
+  it("builds a week-coverage roster body", function () {
+    const xml = buildRosterPayload({ week: 10 }, [
+      { player_key: "nfl.p.1", position: "WR" },
+      { player_key: "nfl.p.2", position: "BN" },
+    ]);
+    expect(xml).toBe(
+      "<?xml version='1.0'?><fantasy_content><roster>" +
+        "<coverage_type>week</coverage_type><week>10</week><players>" +
+        "<player><player_key>nfl.p.1</player_key><position>WR</position></player>" +
+        "<player><player_key>nfl.p.2</player_key><position>BN</position></player>" +
+        "</players></roster></fantasy_content>"
+    );
+  });
+
+  it("builds a date-coverage roster body", function () {
+    const xml = buildRosterPayload({ date: "2026-05-17" }, [
+      { player_key: "nba.p.9", position: "PG" },
+    ]);
+    expect(xml).toBe(
+      "<?xml version='1.0'?><fantasy_content><roster>" +
+        "<coverage_type>date</coverage_type><date>2026-05-17</date><players>" +
+        "<player><player_key>nba.p.9</player_key><position>PG</position></player>" +
+        "</players></roster></fantasy_content>"
+    );
   });
 });


### PR DESCRIPTION
Adds api() PUT/DELETE+XML, xmlHelper, roster.update(). Also fixes a pre-existing test:all type-scaffold
  breakage (type-only). Unit-tested only (writes excluded from integration). Spec/plan in docs/superpowers/.